### PR TITLE
Improve Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,19 @@ software for the time being.
 
 ![I have no idea what I'm doing](https://user-images.githubusercontent.com/519171/45828811-7f984700-bcc7-11e8-8ff5-114ff55d9014.gif)
 
-
 ## Usage
+
+### Preliminaries
+
+```shell
+go get github.com/octokit/go-octokit/octokit
+go build
+```
+
+### Running `go-make-labels`
 
 Populate label configuration in `example.json` and run
 
 ```shell
-export OCTOKIT_ACCESS_TOKEN=1234567890
-go run main.go "kylemacey/go-make-labels"
+OCTOKIT_ACCESS_TOKEN=1234567890 ./go-make-labels "kylemacey/go-make-labels"
 ```

--- a/main.go
+++ b/main.go
@@ -14,6 +14,12 @@ import (
 )
 
 func main() {
+	if len(os.Args) != 2 {
+		fmt.Printf("Usage: %s <user/repository>\n\n", os.Args[0])
+		fmt.Println("Don't forget to set the environment variable OCTOKIT_ACCESS_TOKEN.")
+		return
+	}
+
 	client := octokit.NewClient(getAuthMethod())
 
 	labels, result := client.Labels().All(nil, getRepoParams())

--- a/main.go
+++ b/main.go
@@ -4,111 +4,112 @@
 package main
 
 import (
-  "os"
-  "fmt"
-  "io/ioutil"
-  "strings"
-  "github.com/octokit/go-octokit/octokit"
-  "encoding/json"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/octokit/go-octokit/octokit"
 )
 
-func main () {
-  client := octokit.NewClient(getAuthMethod())
+func main() {
+	client := octokit.NewClient(getAuthMethod())
 
-  labels, result := client.Labels().All(nil, getRepoParams())
+	labels, result := client.Labels().All(nil, getRepoParams())
 
-  handleRequestError(result)
+	handleRequestError(result)
 
-  userlabels := make([]UserLabel,0)
+	userlabels := make([]UserLabel, 0)
 
-  json.Unmarshal(getJsonFromFile("example.json"), &userlabels)
+	json.Unmarshal(getJsonFromFile("example.json"), &userlabels)
 
-  for i := 0; i < len(userlabels); i++ {
-    if contains(labels, userlabels[i].Name) {
-      updateLabel(userlabels[i], client)
-    } else {
-      createLabel(userlabels[i], client)
-    }
-  }
+	for i := 0; i < len(userlabels); i++ {
+		if contains(labels, userlabels[i].Name) {
+			updateLabel(userlabels[i], client)
+		} else {
+			createLabel(userlabels[i], client)
+		}
+	}
 }
 
 func getAuthMethod() octokit.TokenAuth {
-  return octokit.TokenAuth{AccessToken: os.Getenv("OCTOKIT_ACCESS_TOKEN")}
+	return octokit.TokenAuth{AccessToken: os.Getenv("OCTOKIT_ACCESS_TOKEN")}
 }
 
 func handleRequestError(result *octokit.Result) {
-  res := *result
-  if res.HasError() {
-    fmt.Println(res.Error())
-  }
+	res := *result
+	if res.HasError() {
+		fmt.Println(res.Error())
+	}
 }
 
 func getRepoParams() octokit.M {
-  owner, repo := getOwnerAndRepoName()
-  return octokit.M{"owner": owner, "repo": repo}
+	owner, repo := getOwnerAndRepoName()
+	return octokit.M{"owner": owner, "repo": repo}
 }
 
 func getLabelParams(labelName string) octokit.M {
-  owner, repo := getOwnerAndRepoName()
-  return octokit.M{"owner": owner, "repo": repo, "name": labelName}
+	owner, repo := getOwnerAndRepoName()
+	return octokit.M{"owner": owner, "repo": repo, "name": labelName}
 }
 
 func getOwnerAndRepoName() (string, string) {
-  owner_repo_name := strings.Split(os.Args[1], "/")
-  return owner_repo_name[0], owner_repo_name[1]
+	owner_repo_name := strings.Split(os.Args[1], "/")
+	return owner_repo_name[0], owner_repo_name[1]
 }
 
 func updateLabel(userLabel UserLabel, octokitClient *octokit.Client) {
-  client := *octokitClient
-  fmt.Println("Updating `" + userLabel.Name + "`...")
-  _, result := client.Labels().Update(nil, getLabelParams(userLabel.Name), octokit.M{
-    "color" : userLabel.Color,
-    // There is no support in go-octokit yet for description, but it doesn't
-    // hurt to leave it here until it gets implemented
-    "description" : userLabel.Description,
-  })
-  handleRequestError(result)
+	client := *octokitClient
+	fmt.Println("Updating `" + userLabel.Name + "`...")
+	_, result := client.Labels().Update(nil, getLabelParams(userLabel.Name), octokit.M{
+		"color": userLabel.Color,
+		// There is no support in go-octokit yet for description, but it doesn't
+		// hurt to leave it here until it gets implemented
+		"description": userLabel.Description,
+	})
+	handleRequestError(result)
 }
 
 func createLabel(userLabel UserLabel, octokitClient *octokit.Client) {
-  client := *octokitClient
-  fmt.Println("Creating `" + userLabel.Name + "`...")
-  _, result := client.Labels().Create(nil, getRepoParams(), octokit.M{
-    "name" : userLabel.Name,
-    "color" : userLabel.Color,
-    // There is no support in go-octokit yet for description, but it doesn't
-    // hurt to leave it here until it gets implemented
-    "description" : userLabel.Description,
-  })
-  handleRequestError(result)
+	client := *octokitClient
+	fmt.Println("Creating `" + userLabel.Name + "`...")
+	_, result := client.Labels().Create(nil, getRepoParams(), octokit.M{
+		"name":  userLabel.Name,
+		"color": userLabel.Color,
+		// There is no support in go-octokit yet for description, but it doesn't
+		// hurt to leave it here until it gets implemented
+		"description": userLabel.Description,
+	})
+	handleRequestError(result)
 }
 
 func contains(arr []octokit.Label, str string) bool {
-  for i := 0; i < len(arr); i++ {
-    if strings.ToLower(arr[i].Name) == strings.ToLower(str) {
-      return true
-    }
-  }
-  return false
+	for i := 0; i < len(arr); i++ {
+		if strings.ToLower(arr[i].Name) == strings.ToLower(str) {
+			return true
+		}
+	}
+	return false
 }
 
 func getJsonFromFile(path string) []byte {
-  jsonFile, err := os.Open(path)
+	jsonFile, err := os.Open(path)
 
-  // if we os.Open returns an error then handle it
-  if err != nil {
-  	fmt.Println(err)
-  }
+	// if we os.Open returns an error then handle it
+	if err != nil {
+		fmt.Println(err)
+	}
 
-  defer jsonFile.Close()
+	defer jsonFile.Close()
 
-  byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := ioutil.ReadAll(jsonFile)
 
-  return byteValue
+	return byteValue
 }
 
 type UserLabel struct {
-  Name string
-  Color string
-  Description string
+	Name        string
+	Color       string
+	Description string
 }


### PR DESCRIPTION
Hi kylemacey,

Golang has an [extensive style guide](https://golang.org/doc/effective_go.html) that you could read through, or use as reference now and then.

I've done two things. The first one will probably save you a lot of time when developing Go code: [`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports). It automatically formats your source files and sets your imports. It's highly recommend to format your source code, either by the standard distributed `go fmt`, or the external tool `goimports`.

The second one is part of your request in #2. `go build` is typically the command to build the `main` package. Also, I had to use `go get` to get the `octokit/go-octokit` dependency, so I've added that as a preliminary.

Moreover, I've added a check that shows a short usage message when too few or too many command line arguments are given. In the first case, I would get the following `panic`:
```
$ ./go-make-labels 
panic: runtime error: index out of range

goroutine 1 [running]:
main.getOwnerAndRepoName(0x0, 0xc000096300, 0xc0000afef0, 0x63ca18)
	/home/mrngm/scm/go-make-labels/main.go:57 +0xab
main.getRepoParams(0x71a900)
	/home/mrngm/scm/go-make-labels/main.go:47 +0x26
main.main()
	/home/mrngm/scm/go-make-labels/main.go:18 +0x99
```

After this pull request, you would get the following message:
```
$ ./go-make-labels 
Usage: ./go-make-labels <user/repository>

Don't forget to set the environment variable OCTOKIT_ACCESS_TOKEN.
```