### PR TITLE
Pass labels JSON via command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,19 @@ software for the time being.
 
 ![I have no idea what I'm doing](https://user-images.githubusercontent.com/519171/45828811-7f984700-bcc7-11e8-8ff5-114ff55d9014.gif)
 
-
 ## Usage
+
+### Preliminaries
+
+```shell
+go get github.com/octokit/go-octokit/octokit
+go build
+```
+
+### Running `go-make-labels`
 
 Populate label configuration in `example.json` and run
 
 ```shell
-export OCTOKIT_ACCESS_TOKEN=1234567890
-go run main.go "kylemacey/go-make-labels"
+OCTOKIT_ACCESS_TOKEN=1234567890 ./go-make-labels "kylemacey/go-make-labels"
 ```

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -14,8 +15,13 @@ import (
 )
 
 func main() {
-	if len(os.Args) != 2 {
-		fmt.Printf("Usage: %s <user/repository>\n\n", os.Args[0])
+	jsonFile := flag.String("json", "example.json", "Use this JSON file for user labels")
+	flag.Parse()
+
+	if len(flag.Args()) != 1 {
+		fmt.Printf("Usage: %s [-json file] <user/repository>\n\n", os.Args[0])
+		flag.PrintDefaults()
+		fmt.Println()
 		fmt.Println("Don't forget to set the environment variable OCTOKIT_ACCESS_TOKEN.")
 		return
 	}
@@ -28,7 +34,7 @@ func main() {
 
 	userlabels := make([]UserLabel, 0)
 
-	json.Unmarshal(getJsonFromFile("example.json"), &userlabels)
+	json.Unmarshal(getJsonFromFile(*jsonFile), &userlabels)
 
 	for i := 0; i < len(userlabels); i++ {
 		if contains(labels, userlabels[i].Name) {

--- a/main.go
+++ b/main.go
@@ -14,6 +14,12 @@ import (
 )
 
 func main() {
+	if len(os.Args) != 2 {
+		fmt.Printf("Usage: %s <user/repository>\n\n", os.Args[0])
+		fmt.Println("Don't forget to set the environment variable OCTOKIT_ACCESS_TOKEN.")
+		return
+	}
+
 	client := octokit.NewClient(getAuthMethod())
 
 	labels, result := client.Labels().All(nil, getRepoParams())

--- a/main.go
+++ b/main.go
@@ -4,111 +4,112 @@
 package main
 
 import (
-  "os"
-  "fmt"
-  "io/ioutil"
-  "strings"
-  "github.com/octokit/go-octokit/octokit"
-  "encoding/json"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/octokit/go-octokit/octokit"
 )
 
-func main () {
-  client := octokit.NewClient(getAuthMethod())
+func main() {
+	client := octokit.NewClient(getAuthMethod())
 
-  labels, result := client.Labels().All(nil, getRepoParams())
+	labels, result := client.Labels().All(nil, getRepoParams())
 
-  handleRequestError(result)
+	handleRequestError(result)
 
-  userlabels := make([]UserLabel,0)
+	userlabels := make([]UserLabel, 0)
 
-  json.Unmarshal(getJsonFromFile("example.json"), &userlabels)
+	json.Unmarshal(getJsonFromFile("example.json"), &userlabels)
 
-  for i := 0; i < len(userlabels); i++ {
-    if contains(labels, userlabels[i].Name) {
-      updateLabel(userlabels[i], client)
-    } else {
-      createLabel(userlabels[i], client)
-    }
-  }
+	for i := 0; i < len(userlabels); i++ {
+		if contains(labels, userlabels[i].Name) {
+			updateLabel(userlabels[i], client)
+		} else {
+			createLabel(userlabels[i], client)
+		}
+	}
 }
 
 func getAuthMethod() octokit.TokenAuth {
-  return octokit.TokenAuth{AccessToken: os.Getenv("OCTOKIT_ACCESS_TOKEN")}
+	return octokit.TokenAuth{AccessToken: os.Getenv("OCTOKIT_ACCESS_TOKEN")}
 }
 
 func handleRequestError(result *octokit.Result) {
-  res := *result
-  if res.HasError() {
-    fmt.Println(res.Error())
-  }
+	res := *result
+	if res.HasError() {
+		fmt.Println(res.Error())
+	}
 }
 
 func getRepoParams() octokit.M {
-  owner, repo := getOwnerAndRepoName()
-  return octokit.M{"owner": owner, "repo": repo}
+	owner, repo := getOwnerAndRepoName()
+	return octokit.M{"owner": owner, "repo": repo}
 }
 
 func getLabelParams(labelName string) octokit.M {
-  owner, repo := getOwnerAndRepoName()
-  return octokit.M{"owner": owner, "repo": repo, "name": labelName}
+	owner, repo := getOwnerAndRepoName()
+	return octokit.M{"owner": owner, "repo": repo, "name": labelName}
 }
 
 func getOwnerAndRepoName() (string, string) {
-  owner_repo_name := strings.Split(os.Args[1], "/")
-  return owner_repo_name[0], owner_repo_name[1]
+	owner_repo_name := strings.Split(os.Args[1], "/")
+	return owner_repo_name[0], owner_repo_name[1]
 }
 
 func updateLabel(userLabel UserLabel, octokitClient *octokit.Client) {
-  client := *octokitClient
-  fmt.Println("Updating `" + userLabel.Name + "`...")
-  _, result := client.Labels().Update(nil, getLabelParams(userLabel.Name), octokit.M{
-    "color" : userLabel.Color,
-    // There is no support in go-octokit yet for description, but it doesn't
-    // hurt to leave it here until it gets implemented
-    "description" : userLabel.Description,
-  })
-  handleRequestError(result)
+	client := *octokitClient
+	fmt.Println("Updating `" + userLabel.Name + "`...")
+	_, result := client.Labels().Update(nil, getLabelParams(userLabel.Name), octokit.M{
+		"color": userLabel.Color,
+		// There is no support in go-octokit yet for description, but it doesn't
+		// hurt to leave it here until it gets implemented
+		"description": userLabel.Description,
+	})
+	handleRequestError(result)
 }
 
 func createLabel(userLabel UserLabel, octokitClient *octokit.Client) {
-  client := *octokitClient
-  fmt.Println("Creating `" + userLabel.Name + "`...")
-  _, result := client.Labels().Create(nil, getRepoParams(), octokit.M{
-    "name" : userLabel.Name,
-    "color" : userLabel.Color,
-    // There is no support in go-octokit yet for description, but it doesn't
-    // hurt to leave it here until it gets implemented
-    "description" : userLabel.Description,
-  })
-  handleRequestError(result)
+	client := *octokitClient
+	fmt.Println("Creating `" + userLabel.Name + "`...")
+	_, result := client.Labels().Create(nil, getRepoParams(), octokit.M{
+		"name":  userLabel.Name,
+		"color": userLabel.Color,
+		// There is no support in go-octokit yet for description, but it doesn't
+		// hurt to leave it here until it gets implemented
+		"description": userLabel.Description,
+	})
+	handleRequestError(result)
 }
 
 func contains(arr []octokit.Label, str string) bool {
-  for i := 0; i < len(arr); i++ {
-    if strings.ToLower(arr[i].Name) == strings.ToLower(str) {
-      return true
-    }
-  }
-  return false
+	for i := 0; i < len(arr); i++ {
+		if strings.ToLower(arr[i].Name) == strings.ToLower(str) {
+			return true
+		}
+	}
+	return false
 }
 
 func getJsonFromFile(path string) []byte {
-  jsonFile, err := os.Open(path)
+	jsonFile, err := os.Open(path)
 
-  // if we os.Open returns an error then handle it
-  if err != nil {
-  	fmt.Println(err)
-  }
+	// if we os.Open returns an error then handle it
+	if err != nil {
+		fmt.Println(err)
+	}
 
-  defer jsonFile.Close()
+	defer jsonFile.Close()
 
-  byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := ioutil.ReadAll(jsonFile)
 
-  return byteValue
+	return byteValue
 }
 
 type UserLabel struct {
-  Name string
-  Color string
-  Description string
+	Name        string
+	Color       string
+	Description string
 }


### PR DESCRIPTION
I've based this branch on my other pull request #4, because of the default formatting in Go.

This commit adds the possibility to use another JSON file, like `./go-make-labels -json labels.json mrngm/go-make-labels`. Its default is `example.json` to maintain backwards compatibility.

Fixes: #1 